### PR TITLE
[WIP] Anarchic Layering - THE SCRONGLIEST C# WE'VE WRITTEN TO DATE

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -243,7 +243,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         var applyUndergarmentTop = censorNudity;
         var applyUndergarmentBottom = censorNudity;
 
-        if (_configurationManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+        if (_configurationManager.GetCVar(CitCVars.ChargenAnarchicLayering))
         {
             foreach (var marking in humanoid.MarkingSet.AnarchicLayers)
             {

--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -1,4 +1,5 @@
 using Content.Client.DisplacementMap;
+using Content.Shared._Citadel.CCVar;
 using Content.Shared.CCVar;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
@@ -242,9 +243,9 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         var applyUndergarmentTop = censorNudity;
         var applyUndergarmentBottom = censorNudity;
 
-        foreach (var markingList in humanoid.MarkingSet.Markings.Values)
+        if (_configurationManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
         {
-            foreach (var marking in markingList)
+            foreach (var marking in humanoid.MarkingSet.AnarchicLayers)
             {
                 if (_markingManager.TryGetMarking(marking, out var markingPrototype))
                 {
@@ -253,6 +254,23 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
                         applyUndergarmentTop = false;
                     else if (markingPrototype.BodyPart == HumanoidVisualLayers.UndergarmentBottom)
                         applyUndergarmentBottom = false;
+                }
+            }
+        }
+        else
+        {
+            foreach (var markingList in humanoid.MarkingSet.Markings.Values)
+            {
+                foreach (var marking in markingList)
+                {
+                    if (_markingManager.TryGetMarking(marking, out var markingPrototype))
+                    {
+                        ApplyMarking(markingPrototype, marking.MarkingColors, marking.Visible, entity);
+                        if (markingPrototype.BodyPart == HumanoidVisualLayers.UndergarmentTop)
+                            applyUndergarmentTop = false;
+                        else if (markingPrototype.BodyPart == HumanoidVisualLayers.UndergarmentBottom)
+                            applyUndergarmentBottom = false;
+                    }
                 }
             }
         }

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._Citadel.CCVar;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Humanoid.Prototypes;
@@ -8,6 +9,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Client.Utility;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
@@ -20,6 +22,7 @@ public sealed partial class MarkingPicker : Control
     [Dependency] private readonly MarkingManager _markingManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
 
     private readonly SpriteSystem _sprite;
 
@@ -248,7 +251,16 @@ public sealed partial class MarkingPicker : Control
             _currentMarkings.EnsureSpecies(_currentSpecies, null, _markingManager);
         }
 
-        var markingList = _currentMarkings.GetReverseEnumerator();
+        IEnumerable<Marking> markingList;
+        if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+        {
+            markingList = _currentMarkings.AnarchicLayers;
+        }
+        else
+        {
+            markingList = _currentMarkings.GetReverseEnumerator(_selectedMarkingCategory);
+        }
+        //var markingList = _currentMarkings.GetReverseEnumerator();
 
         // walk backwards through the list for visual purposes
         //foreach (var marking in _currentMarkings.GetReverseEnumerator(_selectedMarkingCategory))
@@ -317,6 +329,12 @@ public sealed partial class MarkingPicker : Control
         var visualTemp = CMarkingsUsed[visualDest];
         CMarkingsUsed[visualDest] = CMarkingsUsed[src];
         CMarkingsUsed[src] = visualTemp;
+
+        if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+        {
+            _currentMarkings.ShiftRankAnarchic(places, _currentMarkings.AnarchicLayers[src]);
+            return true;
+        }
 
         switch (places)
         {
@@ -424,9 +442,19 @@ public sealed partial class MarkingPicker : Control
             colorContainer.AddChild(new Label { Text = $"{stateNames[i]} color:" });
             colorContainer.AddChild(colorSelector);
 
-            var listing = _currentMarkings.Markings[_selectedMarkingCategory];
+            Marking targetmarking;
+            if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+            {
+                targetmarking = _currentMarkings.AnarchicLayers[item.ItemIndex];
+            }
+            else
+            {
+                var listing = _currentMarkings.Markings[_selectedMarkingCategory];
+                targetmarking = listing[listing.Count - 1 - item.ItemIndex];
+            }
+            //var listing = _currentMarkings.Markings[_selectedMarkingCategory];
 
-            var color = listing[listing.Count - 1 - item.ItemIndex].MarkingColors[i];
+            var color = targetmarking.MarkingColors[i];
             var currentColor = new Color(
                 color.RByte,
                 color.GByte,
@@ -458,7 +486,17 @@ public sealed partial class MarkingPicker : Control
 
         _selectedMarking.IconModulate = _currentMarkingColors[colorIndex];
 
-        var marking = new Marking(_currentMarkings.Markings[_selectedMarkingCategory][markingIndex]);
+        List<Marking> listing;
+        if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+        {
+            listing = _currentMarkings.AnarchicLayers;
+        }
+        else
+        {
+            listing = _currentMarkings.Markings[_selectedMarkingCategory];
+        }
+
+        var marking = new Marking(listing[markingIndex]);
         marking.SetColor(colorIndex, _currentMarkingColors[colorIndex]);
         _currentMarkings.Replace(_selectedMarkingCategory, markingIndex, marking);
 
@@ -537,7 +575,7 @@ public sealed partial class MarkingPicker : Control
 
         var marking = (MarkingPrototype) _selectedMarking.Metadata!;
 
-        _currentMarkings.Remove(_selectedMarkingCategory, marking.ID);
+        _currentMarkings.Remove(marking.MarkingCategory, marking.ID);
 
         UpdatePoints();
 

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -248,8 +248,11 @@ public sealed partial class MarkingPicker : Control
             _currentMarkings.EnsureSpecies(_currentSpecies, null, _markingManager);
         }
 
+        var markingList = _currentMarkings.GetReverseEnumerator();
+
         // walk backwards through the list for visual purposes
-        foreach (var marking in _currentMarkings.GetReverseEnumerator(_selectedMarkingCategory))
+        //foreach (var marking in _currentMarkings.GetReverseEnumerator(_selectedMarkingCategory))
+        foreach (var marking in markingList)
         {
             if (!_markingManager.TryGetMarking(marking, out var newMarking))
             {

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -252,7 +252,7 @@ public sealed partial class MarkingPicker : Control
         }
 
         IEnumerable<Marking> markingList;
-        if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+        if (_configManager.GetCVar(CitCVars.ChargenAnarchicLayering))
         {
             markingList = _currentMarkings.AnarchicLayers;
         }
@@ -330,7 +330,7 @@ public sealed partial class MarkingPicker : Control
         CMarkingsUsed[visualDest] = CMarkingsUsed[src];
         CMarkingsUsed[src] = visualTemp;
 
-        if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+        if (_configManager.GetCVar(CitCVars.ChargenAnarchicLayering))
         {
             _currentMarkings.ShiftRankAnarchic(places, _currentMarkings.AnarchicLayers[src]);
             return true;
@@ -443,7 +443,7 @@ public sealed partial class MarkingPicker : Control
             colorContainer.AddChild(colorSelector);
 
             Marking targetmarking;
-            if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+            if (_configManager.GetCVar(CitCVars.ChargenAnarchicLayering))
             {
                 targetmarking = _currentMarkings.AnarchicLayers[item.ItemIndex];
             }
@@ -487,7 +487,7 @@ public sealed partial class MarkingPicker : Control
         _selectedMarking.IconModulate = _currentMarkingColors[colorIndex];
 
         List<Marking> listing;
-        if (_configManager.GetCVar(CitCVars.ChargenAllowsAnarchy))
+        if (_configManager.GetCVar(CitCVars.ChargenAnarchicLayering))
         {
             listing = _currentMarkings.AnarchicLayers;
         }

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -51,8 +51,18 @@ public sealed partial class MarkingSet
     [DataField("points")]
     public Dictionary<MarkingCategories, MarkingPoints> Points = new();
 
+
+    /// <summary>
+    ///     Citadel-specific change
+    ///     This keeps track of the actual layering of markings, enabling arbitrary
+    ///     layering of markings, just like the OG MarkingSet, just like chargen in
+    ///     most furry SS13 servers
+    /// </summary>
+    [DataField("anarchiclayers")]
+    public List<Marking> AnarchicLayers = new();
+
     public MarkingSet()
-    {}
+    { }
 
     /// <summary>
     ///     Construct a MarkingSet using a list of markings, and a points
@@ -343,6 +353,21 @@ public sealed partial class MarkingSet
         }
 
         markings.Insert(0, marking);
+
+        // Citadel change - anarchic layer orders for SS13 chargen parity
+        AnarchicLayers.Insert(0, marking);
+        /*var anarchicIndex = 0;
+        foreach (MarkingCategories cat in Markings)
+        {
+            if (cat == category)
+            {
+                AnarchicLayers.Insert(anarchicIndex, marking);
+            }
+            else
+            {
+                anarchicIndex += Markings[cat].Count;
+            }
+        }*/
     }
 
     /// <summary>
@@ -370,6 +395,22 @@ public sealed partial class MarkingSet
 
 
         markings.Add(marking);
+
+        // Citadel change - anarchic layer orders for SS13 chargen parity
+        AnarchicLayers.Add(marking);
+        /*var anarchicIndex = 0;
+        foreach (MarkingCategories cat in Markings)
+        {
+            if (cat == category)
+            {
+                anarchicIndex += Markings[cat].Count - 1;
+                AnarchicLayers.Insert(anarchicIndex, marking);
+            }
+            else
+            {
+                anarchicIndex += Markings[cat].Count;
+            }
+        }*/
     }
 
     /// <summary>
@@ -398,6 +439,8 @@ public sealed partial class MarkingSet
             return;
         }
 
+        AnarchicLayers[AnarchicLayers.IndexOf(markings[index])] = marking; // Citadel change - anarchic layer ordering
+
         markings[index] = marking;
     }
 
@@ -425,6 +468,8 @@ public sealed partial class MarkingSet
             {
                 points.Points++;
             }
+
+            AnarchicLayers.Remove(markings[i]); // Citadel change - anarchic layer ordering
 
             markings.RemoveAt(i);
             return true;
@@ -456,6 +501,8 @@ public sealed partial class MarkingSet
             points.Points++;
         }
 
+        AnarchicLayers.Remove(markings[idx]); // Citadel change - anarchic layer ordering
+
         markings.RemoveAt(idx);
     }
 
@@ -482,6 +529,11 @@ public sealed partial class MarkingSet
 
                 points.Points++;
             }
+        }
+
+        foreach (var marking in Markings[category])
+        {
+            AnarchicLayers.Remove(marking);
         }
 
         Markings.Remove(category);

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -356,18 +356,6 @@ public sealed partial class MarkingSet
 
         // Citadel change - anarchic layer orders for SS13 chargen parity
         AnarchicLayers.Insert(0, marking);
-        /*var anarchicIndex = 0;
-        foreach (MarkingCategories cat in Markings)
-        {
-            if (cat == category)
-            {
-                AnarchicLayers.Insert(anarchicIndex, marking);
-            }
-            else
-            {
-                anarchicIndex += Markings[cat].Count;
-            }
-        }*/
     }
 
     /// <summary>
@@ -398,19 +386,6 @@ public sealed partial class MarkingSet
 
         // Citadel change - anarchic layer orders for SS13 chargen parity
         AnarchicLayers.Add(marking);
-        /*var anarchicIndex = 0;
-        foreach (MarkingCategories cat in Markings)
-        {
-            if (cat == category)
-            {
-                anarchicIndex += Markings[cat].Count - 1;
-                AnarchicLayers.Insert(anarchicIndex, marking);
-            }
-            else
-            {
-                anarchicIndex += Markings[cat].Count;
-            }
-        }*/
     }
 
     /// <summary>
@@ -685,18 +660,40 @@ public sealed partial class MarkingSet
     }
 
     /// <summary>
+    ///     Shifts the rank according to the anarchic layer shifting rules
+    ///     Citadel specific proc
+    /// </summary>
+    public void ShiftRankAnarchic(int shift, Marking marking)
+    {
+        var idx = AnarchicLayers.IndexOf(marking);
+        if (idx == -1)
+        {
+            return;
+        }
+
+        var targetpos = idx + shift;
+        if (targetpos < 0 || targetpos >= AnarchicLayers.Count)
+        {
+            return;
+        }
+        (AnarchicLayers[idx + shift], AnarchicLayers[idx]) = (AnarchicLayers[idx], AnarchicLayers[idx + shift]);
+    }
+
+    /// <summary>
     ///     Gets all markings in this set as an enumerator. Lists will be organized, but categories may be in any order.
     /// </summary>
     /// <returns>An enumerator of <see cref="Marking"/>s.</returns>
     public ForwardMarkingEnumerator GetForwardEnumerator()
     {
-        var markings = new List<Marking>();
+        return new ForwardMarkingEnumerator(AnarchicLayers);
+
+        /*var markings = new List<Marking>();
         foreach (var (_, list) in Markings)
         {
             markings.AddRange(list);
         }
 
-        return new ForwardMarkingEnumerator(markings);
+        return new ForwardMarkingEnumerator(markings);*/
     }
 
     /// <summary>
@@ -721,13 +718,15 @@ public sealed partial class MarkingSet
     /// <returns>An enumerator of <see cref="Marking"/>s in reverse.</returns>
     public ReverseMarkingEnumerator GetReverseEnumerator()
     {
-        var markings = new List<Marking>();
+        return new ReverseMarkingEnumerator(AnarchicLayers);
+
+        /*var markings = new List<Marking>();
         foreach (var (_, list) in Markings)
         {
             markings.AddRange(list);
         }
 
-        return new ReverseMarkingEnumerator(markings);
+        return new ReverseMarkingEnumerator(markings);*/
     }
 
     /// <summary>

--- a/Content.Shared/_Citadel/CCVar/CCVars.Citadel.Chargen.cs
+++ b/Content.Shared/_Citadel/CCVar/CCVars.Citadel.Chargen.cs
@@ -12,6 +12,6 @@ public sealed partial class CitCVars
     ///     layer ordering of markings
     /// </summary>
     [CVarControl(AdminFlags.Server)]
-    public static readonly CVarDef<bool> ChargenAllowsAnarchy =
-        CVarDef.Create("citadel.chargen.allow_anarchy", true, CVar.SERVER | CVar.REPLICATED);
+    public static readonly CVarDef<bool> ChargenAnarchicLayering =
+        CVarDef.Create("citadel.chargen.anarchic_layering", true, CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/_Citadel/CCVar/CCVars.Citadel.Chargen.cs
+++ b/Content.Shared/_Citadel/CCVar/CCVars.Citadel.Chargen.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Administration;
+using Content.Shared.CCVar.CVarAccess;
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Citadel.CCVar;
+
+public sealed partial class CitCVars
+{
+
+    /// <summary>
+    ///     Whether or not character generation allows unlimited points and arbitrary
+    ///     layer ordering of markings
+    /// </summary>
+    [CVarControl(AdminFlags.Server)]
+    public static readonly CVarDef<bool> ChargenAllowsAnarchy =
+        CVarDef.Create("citadel.chargen.allow_anarchy", true, CVar.SERVER | CVar.REPLICATED);
+}

--- a/Content.Shared/_Citadel/CCVar/CCVars.Citadel.cs
+++ b/Content.Shared/_Citadel/CCVar/CCVars.Citadel.cs
@@ -1,0 +1,9 @@
+using Robust.Shared;
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Citadel.CCVar;
+
+[CVarDefs]
+public sealed partial class CitCVars : CVars
+{
+}


### PR DESCRIPTION
this shit is NOT makin it upstream as-is lmaooooooooo

you, the viewer, should NOT follow this PR as an example for Anything. this PR is us being a bad rolemodel.

doing this proper would require a rewrite of markingsets (markingsets are fairly scronkly code to begin with and we're making it actively worse here), but that would be better done upstream than down here. however, we're not particularly confident that anarchic layering would even be accepted upstream on a base conceptual level, which would make an upstream rewrite questionable. so for now? shitcode directly in upstream code.

Anyhow, this is an implementation of anarchic layering as planned in #388 

known issues thus far:
- coloring is completely broken and requires you to perform a ritual (of which not even we know the conditions of) to successfully color what you want to color. if you fail this ritual, the item you selected will transmute itself into a random marking and corrupt the colors of all other markings. What The Fuck??
- layer order shifting is broken until you change to a different marking category
- the code does not yet properly encapsulate all of the anarchic layering behavior within the anarchic layering cvar, so disabling it will lead to things imploding
- diff is very dirty and needs cleanup + cit change markings

**Changelog**

:cl: Bhijn and Myr
- add: Markings can now be sorted in any arbitrary order

